### PR TITLE
Restrict with of thumbnails

### DIFF
--- a/app/assets/stylesheets/hyrax/_representative-media.scss
+++ b/app/assets/stylesheets/hyrax/_representative-media.scss
@@ -1,11 +1,11 @@
 .representative-media {
   display: block;
   padding: 0.5em 0;
-  width: 250px;
+  width: 100%;
 }
 
 .canonical-image {
   display: block;
   padding: 0.5em 0;
-  width: 250px;
+  width: 100%;
 }


### PR DESCRIPTION
.representative-media and .canonical-image are already in columns with set widths. Set their widths to 100% of the parent, which changes depending on the size of the viewport.

Fixes #4768; refs #2239

@samvera/hyrax-code-reviewers
